### PR TITLE
Fixes

### DIFF
--- a/bundle_adjust/asift.py
+++ b/bundle_adjust/asift.py
@@ -27,7 +27,6 @@ import cv2 as cv
 import sys
 
 # built-in modules
-import itertools as it
 from multiprocessing.pool import ThreadPool
 
 FLANN_INDEX_KDTREE = 1  # bug: flann enums are missing

--- a/bundle_adjust/ba_pipeline.py
+++ b/bundle_adjust/ba_pipeline.py
@@ -4,7 +4,7 @@ import os
 import time
 import json
 import matplotlib.pyplot as plt
-from scipy.optimize import least_squares, minimize
+from scipy.optimize import least_squares
 from PIL import Image
 
 from bundle_adjust import ba_utils

--- a/bundle_adjust/ba_timeseries.py
+++ b/bundle_adjust/ba_timeseries.py
@@ -4,7 +4,6 @@ import matplotlib.pyplot as plt
 import glob
 import rpcm
 import os
-import rasterio
 import pickle
 import subprocess
 import srtm4
@@ -892,7 +891,6 @@ class Scene:
             initial_rpc = rpcm.RPCModel(config_s2p['images'][0]['rpc'], dict_format = "rpcm")
             roi_lons_init = np.array(config_s2p['roi_geojson']['coordinates'][0])[:,0]
             roi_lats_init = np.array(config_s2p['roi_geojson']['coordinates'][0])[:,1]
-            import srtm4
             alt = srtm4.srtm4(np.mean(roi_lons_init), np.mean(roi_lats_init))           
             roi_cols_init, roi_rows_init = initial_rpc.projection(roi_lons_init, roi_lats_init, [alt]*roi_lons_init.shape[0])
             roi_lons_ba, roi_lats_ba = correct_rpc.localization(roi_cols_init, roi_rows_init, [alt]*roi_lons_init.shape[0])
@@ -913,7 +911,6 @@ class Scene:
             if dsm_idx == 0:
                 aoi_lons_init = np.array(self.aoi_lonlat['coordinates'][0])[:,0]
                 aoi_lats_init = np.array(self.aoi_lonlat['coordinates'][0])[:,1]
-                import srtm4
                 alt = srtm4.srtm4(np.mean(aoi_lons_init), np.mean(aoi_lats_init))
                 aoi_cols_init, aoi_rows_init = initial_rpc.projection(aoi_lons_init, aoi_lats_init, 
                                                                      [alt]*aoi_lons_init.shape[0])

--- a/bundle_adjust/ba_utils.py
+++ b/bundle_adjust/ba_utils.py
@@ -6,22 +6,12 @@
 
 import numpy as np
 import matplotlib.pyplot as plt
-from scipy import linalg
 
-from IS18 import rectification
-from IS18 import vistools
-from IS18 import stereo
-from IS18 import utils
-
-import cv2
 import re
-import math
 import os
 from PIL import Image
 import srtm4
-import rpcm
-from shapely.geometry import Polygon, mapping, shape
-import geojson
+from shapely.geometry import shape
 import rasterio
 
 def get_predefined_pairs(fname, site, order, myimages):

--- a/bundle_adjust/data_loader.py
+++ b/bundle_adjust/data_loader.py
@@ -4,7 +4,6 @@ such scenes can contain 1 date or multiple dates
 '''''''''
 
 import numpy as np
-import matplotlib.pyplot as plt
 
 import glob
 import os
@@ -13,9 +12,9 @@ import rpcm
 import datetime
 from PIL import Image
 import rasterio
+import srtm4
 
 from IS18 import utils
-from bundle_adjust import ba_utils
 from bundle_adjust import geojson_utils
 
 

--- a/bundle_adjust/ortographic.py
+++ b/bundle_adjust/ortographic.py
@@ -1,8 +1,7 @@
 import numpy as np
 from scipy.linalg import cholesky
-from scipy import linalg
 from scipy.sparse import lil_matrix
-from ba_utils import rotate_euler, euler_angles_from_R, euler_angles_to_R, corresp_matrix_from_tracks
+from ba_utils import rotate_euler, euler_angles_from_R, euler_angles_to_R
 
 
 def ortographic_pose_estimation(corresp, calM):

--- a/bundle_adjust/rpc_utils.py
+++ b/bundle_adjust/rpc_utils.py
@@ -6,7 +6,6 @@
 from __future__ import print_function
 import bs4
 import json
-import datetime
 import pyproj
 import warnings
 import rasterio


### PR DESCRIPTION
This PR includes a few miscellaneous fixes or modifications to the code. The changes are listed below, and mentionned in the commit messages:

- Remove unused imports
- Use `rasterio` instead of `ImageMagick` to read image size
- Fix: replace `rpc_model.RPCModel` with `rpcm.RPCModel`
	The `rpc_model.RPCModel` class does not exist, you probably meant
	`rpcm.rpc_model.RPCModel`, which can also be imported through the shorter
	`rpcm.RPCModel`.
- Formalize `rpc_src` parameter
	This parameter can take the following values:
	- `s2p_configs` to load the RPCs from the s2p config JSON files
	- `geotiff` to load the RPCs from the geotiff files
	- `txt` to load the RPCs from the _RPC.TXT files accompanying the geotiffs
	- `json` to load the RPCs from the .json files accompanying the geotiffs
- Make `s2p_configs_dir`
	Without these changes, the code would crash if `s2p_configs_dir` was not
	present in the config JSON, even though this directory is not mandatory.
- [fix] Remove return from `Scene.__init__`
	A python `__init__()` method should not return anything, otherwise this
	exception is raised:
	TypeError: `__init__()` should return None, not 'bool'
	A custom Exception is now raised instead.
- Fix `images_dir` -> `geotiff_dir` variable name
