### PR TITLE
Update datatypes to be compatible with numpy >= 1.20

### DIFF
--- a/bundle_adjust/ba_core.py
+++ b/bundle_adjust/ba_core.py
@@ -458,7 +458,7 @@ def save_heatmap_of_reprojection_error(img_path, p, err, input_ims_footprints_lo
     track_err_interp = gaussian_filter(track_err_interp, sigma=smooth)
 
     # apply mask of image footprints
-    mask = np.ones((height, width)).astype(np.bool)
+    mask = np.ones((height, width)).astype(bool)
     for i, aoi_lonlat in enumerate(input_ims_footprints_lonlat):
         aoi_utm = geo_utils.utm_geojson_from_lonlat_geojson(aoi_lonlat)
         pts2d_utm = np.array(aoi_utm["coordinates"][0])

--- a/bundle_adjust/feature_tracks/ft_opencv.py
+++ b/bundle_adjust/feature_tracks/ft_opencv.py
@@ -52,7 +52,7 @@ def opencv_detect_SIFT(geotiff_path, mask_path=None, offset=None, tracks_config=
 
     if mask_path is not None:
         mask = np.load(mask_path)
-        pts2d_colrow = features_i[:, :2].astype(np.int)
+        pts2d_colrow = features_i[:, :2].astype(np.int32)
         true_if_obs_inside_aoi = mask[pts2d_colrow[:, 1], pts2d_colrow[:, 0]] > 0
         features_i = features_i[true_if_obs_inside_aoi, :]
 

--- a/bundle_adjust/feature_tracks/ft_s2p.py
+++ b/bundle_adjust/feature_tracks/ft_s2p.py
@@ -67,7 +67,7 @@ def detect_features_image_sequence(geotiff_paths, mask_paths=None, offsets=None,
             features_i = features_i[features_i[:, 2] > 1.85, :] # min scale allowed is 1.85
         if mask_paths is not None:
             mask = np.load(mask_paths[i])
-            pts2d_colrow = features_i[:, :2].astype(np.int)
+            pts2d_colrow = features_i[:, :2].astype(np.int32)
             true_if_obs_inside_aoi = mask[pts2d_colrow[:, 1], pts2d_colrow[:, 0]] > 0
             features_i = features_i[true_if_obs_inside_aoi, :]
 

--- a/bundle_adjust/loader.py
+++ b/bundle_adjust/loader.py
@@ -192,11 +192,11 @@ def load_image(path_to_geotiff, offset=None, equalize=False):
     """
     if offset is None:
         with rasterio.open(path_to_geotiff) as src:
-            im = src.read().astype(np.float)
+            im = src.read().astype(np.float32)
     else:
         y0, x0, h, w = offset["row0"], offset["col0"], offset["height"], offset["width"]
         with rasterio.open(path_to_geotiff) as src:
-            im = src.read(window=((y0, y0 + h), (x0, x0 + w))).squeeze().astype(np.float)
+            im = src.read(window=((y0, y0 + h), (x0, x0 + w))).squeeze().astype(np.float32)
 
     # we only work with 1-band images
     if len(im.shape) > 2:


### PR DESCRIPTION
The datatypes `np.bool`, `np.float` and `np.int` have been [deprecated](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations) since numpy 1.20. 

This means running the code with a newer version will result in a crash. 

This PR updates the datatypes. 

The recommended updates for `np.float` and `np.int` are the native datatypes `int` and `float`, but as there were other occasions in the code where `np.float32` and `np.int32` were used, I updated them to these for the sake of consistency. 